### PR TITLE
fix(US): Correct temperature settings to match the kia UVO app and the vehicle

### DIFF
--- a/custom_components/kia_uvo/Vehicle.py
+++ b/custom_components/kia_uvo/Vehicle.py
@@ -181,7 +181,11 @@ class Vehicle:
 
     async def start_climate(self, set_temp, duration, defrost, climate, heating):
         if set_temp is None:
-            set_temp = 21
+            set_temp = 72
+        elif set_temp < 62: 
+            set_temp = 'LOW'
+        elif set_temp > 82:
+            set_temp = 'HIGH'
         if duration is None:
             duration = 5
         if defrost is None:


### PR DESCRIPTION
In the Kia Telluride (and I assume other Kia vehicles) and the Kia UVO app, you are only allowed to set the climate temperature to LOW -> 62-82 <- HIGH. I changed the services.yaml  file to account for this, changed the default temperature from 21 to 72, the min to 60 and the max to 85, and added logic in the vehicle.py file to translate anything < 62 to 'LOW', and anything > 82 to 'HIGH'. 